### PR TITLE
Use AND operation with match_command instead of OR operation

### DIFF
--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -139,7 +139,7 @@ class JoyTeleop:
         for b in self.command_list[c]['buttons']:
             if b < 0 or len(buttons) <= b or buttons[b] != 1:
                 return False
-        return sum(buttons) >= len(self.command_list[c]['buttons'])
+        return sum(buttons) == len(self.command_list[c]['buttons'])
 
     def add_command(self, name, command):
         """Add a command to the command list"""


### PR DESCRIPTION
Currently there is an issue in the joy_teleop that it matches the command even though there are more combination of buttons pressed along with the desired one. This PR intends to fix the issue.


For instance:
```
  # Switch to position controller
  switch_to_position_control:
    type: service
    service_name: /controller_manager/switch_controller
    service_request:
      start_controllers: ["left_leg_controller", "right_leg_controller"]
    buttons: [0, 5, 7]
```

Current behaviour: If I press 0,1,4,5 and 7 button or if I press only 0,5 and 7 buttons it swiches to position control

Intended behaviour: I want it so switch to postiion control only If I press 0,5 and 7